### PR TITLE
Reinstall app

### DIFF
--- a/pebble.py
+++ b/pebble.py
@@ -165,6 +165,13 @@ class Pebble(object):
 		data = pack("!bL", 2, timestamp)
 		self._send_message("TIME", data)
 
+	def reinstall_app(self, name, pbz_path):
+		apps = self.get_appbank_status()
+		for app in apps["apps"]:
+			if app["name"] == name:
+				self.remove_app(app["id"], app["index"])
+		self.install_app(pbz_path)
+
 	def install_app(self, pbz_path):
 		with zipfile.ZipFile(pbz_path) as pbz:
 			binary = pbz.read("pebble-app.bin")


### PR DESCRIPTION
This simply performs an uninstall followed by an install.  It requires
the name of the App in development and the file path.

This will prevent issues with the 8 app limit while in development.
