### PR TITLE
Phone version handler and two little bits

### DIFF
--- a/p.py
+++ b/p.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import pebble as libpebble

--- a/pebble/pebble.py
+++ b/pebble/pebble.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import binascii
 import serial

--- a/pebble/pebble.py
+++ b/pebble/pebble.py
@@ -193,10 +193,6 @@ class Pebble(object):
 				if resp == None:
 					continue
 
-				if DEBUG_PROTOCOL:
-					log.debug("Got message for endpoint %s of length %d" % (endpoint, len(resp)))
-					log.debug('<<< ' + resp.encode('hex'))
-
 				if endpoint in self._internal_endpoint_handlers:
 					resp = self._internal_endpoint_handlers[endpoint](endpoint, resp)
 
@@ -228,6 +224,11 @@ class Pebble(object):
 			raise PebbleError(self.id, "Malformed response with length "+str(len(data)))
 		size, endpoint = unpack("!HH", data)
 		resp = self._ser.read(size)
+
+		if DEBUG_PROTOCOL:
+			log.debug("Got message for endpoint %s of length %d" % (endpoint, len(resp)))
+			log.debug('<<< ' + (data + resp).encode('hex'))
+
 		return (endpoint, resp)
 
 	def register_endpoint(self, endpoint_name, func):

--- a/pebble/pebble.py
+++ b/pebble/pebble.py
@@ -450,6 +450,40 @@ class Pebble(object):
 		if not async:
 			return EndpointSync(self, "PING").get_data()
 
+	phone_control_commands = {
+		"ANSWER" : 1,
+		"HANGUP" : 2,
+		"GET_STATE" : 3,
+		"INCOMING_CALL" : 4,
+		"OUTGOING_CALL" : 5,
+		"MISSED_CALL" : 6,
+		"RING" : 7,
+		"START" : 8,
+		"END" : 9,
+	}
+
+	def phone_incoming(self, number, name, cookie = 0, async = False):
+
+		"""Send a 'phone_control' notification for incoming call."""
+
+		fmt = "!bL" + str(1+len(number)) + "p" + str(1+len(name)) + "p"
+		data = pack(fmt, self.phone_control_commands["INCOMING_CALL"], cookie, number, name)
+		self._send_message("PHONE_CONTROL", data)
+
+	def phone_start(self, cookie = 0, async = False):
+
+		"""Send a 'phone_control' notification of start."""
+
+		data = pack("!bL", self.phone_control_commands["START"], cookie)
+		self._send_message("PHONE_CONTROL", data)
+
+	def phone_end(self, cookie = 0, async = False):
+
+		"""Send a 'phone_control' notification of end."""
+
+		data = pack("!bL", self.phone_control_commands["END"], cookie)
+		self._send_message("PHONE_CONTROL", data)
+
 	def reset(self):
 
 		"""Reset the watch remotely."""

--- a/repl.py
+++ b/repl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import pebble as libpebble


### PR DESCRIPTION
Not sure if the python2 thing will be broken on OS X or elsewhere, but it ends up using python 3 on my machine otherwise.

The phone version endpoint handler doesn't guess the current OS or anything because if you say you're anything but android you don't get music player messages anymore.  I guess we're all android for now!
