### PR TITLE
Noticed that the Subject and Body of email notifications displayed reversed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Getting started
 
 I've only tested this on OS X 10.8. Things will be a little different on other platforms. Firstly make sure you have Python and PySerial installed.
 
-Next, pair your Pebble to your computer and make sure it's setup as a serial port. For me, it gets exposed as /dev/tty.Pebble402F-SerialPortSe. If this is different for you, you'll need to edit pebble.py. The 402F bit is my Pebble's ID. You can just run pebble.py with your ID as an argument if the rest of that path matches.
+Next, pair your Pebble to your computer and make sure it's setup as a serial port. For me, it gets exposed as /dev/tty.Pebble402F-SerialPortSe. If this is different for you anywhere but in 402F, you'll need to edit pebble.py. The 402F bit is my Pebble's ID. You can just run pebble.py with your ID as an argument if the rest of that path matches.
 
-Once you're paired and the serial port is setup, try running pebble.py. You should get a notification on your Pebble to test that it works properly.
+Once you're paired and the serial port is setup, try running `p.py ping`. You should get a notification on your Pebble to test that it works properly. It sometimes helps to tell the Pebble App to disconnect from the Pebble first.
 
 Join #pebble on Freenode IRC to let me know how you get on and share your creations!
 

--- a/p.py
+++ b/p.py
@@ -82,6 +82,9 @@ def cmd_rm_app(pebble, args):
 def cmd_reset(pebble, args):
     pebble.reset()
 
+def cmd_set_nowplaying_metadata(pebble, args):
+    pebble.set_nowplaying_metadata(args.track, args.album, args.artist)
+
 def cmd_notification_email(pebble, args):
     pebble.notification_email(args.sender, args.subject, args.body)
 
@@ -123,6 +126,12 @@ def main():
 
     reset_parser = subparsers.add_parser('reset', help='reset the watch remotely')
     reset_parser.set_defaults(func=cmd_reset)
+
+    set_nowplaying_metadata_parser = subparsers.add_parser('playing', help='set current music playing')
+    set_nowplaying_metadata_parser.add_argument('track', type=str)
+    set_nowplaying_metadata_parser.add_argument('album', type=str)
+    set_nowplaying_metadata_parser.add_argument('artist', type=str)
+    set_nowplaying_metadata_parser.set_defaults(func=cmd_set_nowplaying_metadata)
 
     notification_email_parser = subparsers.add_parser('email', help='send an "Email Notification"')
     notification_email_parser.add_argument('sender', type=str)

--- a/pebble/pebble.py
+++ b/pebble/pebble.py
@@ -21,7 +21,7 @@ log.setLevel(logging.DEBUG)
 
 DEFAULT_PEBBLE_ID = None #Triggers autodetection on unix-like systems
 
-DEBUG_PROTOCOL = True
+DEBUG_PROTOCOL = False
 
 class PebbleBundle(object):
 	MANIFEST_FILENAME = 'manifest.json'


### PR DESCRIPTION
Hi Hexxeh,
Thanks for the nice library; I saw that the subject and body of the email notification were reversed when displayed on my pebble with firmware 1.9.1, so I altered the order in pebble.py. The manual packing of pascal strings was modified to let pack do it with 'p'.
I added a playing command to p.py
I updated a little bit of the README because running pebble.py after pairing doesn't demonstrate successful communication to the end user.

There's a little more detail in the initial commit message for 8adf52c...
