### PR TITLE
Improved setup for plain OSX environments.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lightblue-0.4"]
+	path = lightblue-0.4
+	url = https://github.com/pipt/lightblue-0.4

--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ All supported OS's will require `python 2.7` to operate libpebble. It can be ins
 ###a. OSX Additional Dependencies
 
 Installing Lightblue-0.4 in OSX will require the following be installed:
-* `PyObjC` which can be installed via [pip](https://pypi.python.org/pypi/pip)
 * `Xcode 2.1 or later` to build LightAquaBlue framework
+* Run setup_lightblue.bash as root, `sudo setup_lightblue.bash`. It installs:
+** `PyObjC` 
+** `PySerial` 
+** `lightblue-0.4`
 
 ###b. Ubuntu Additional Dependencies
 

--- a/setup_lightblue.bash
+++ b/setup_lightblue.bash
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+#run as root
+
+easy_install -U pyobjc-core
+easy_install -U pyobjc
+easy_install -U pyserial
+
+git submodule update --init --recursive
+cd lightblue-0.4
+python setup.py install
+
+echo lightblue successfully setup


### PR DESCRIPTION
1. Added submodule for working lightblue-0.4 fork found in the pebble forums: http://forums.getpebble.com/discussion/comment/25607/#Comment_25607
2. Created setup script that installs lightblue and its python dependencies with easy_install. pip didn't work as well for me.
