### PR TITLE
Change "name" to "project_name" during project converstion

### DIFF
--- a/pebble/PblProjectConverter.py
+++ b/pebble/PblProjectConverter.py
@@ -85,7 +85,7 @@ def find_pbl_app_info(project_root):
 
     PBL_APP_INFO_FIELDS = [
             'uuid',
-            'name',
+            'project_name',
             'company_name',
             'version_major',
             'version_minor',
@@ -114,8 +114,7 @@ def extract_c_appinfo(project_root):
 
     appinfo_json_def = {
         'uuid': convert_c_uuid(appinfo_c_def['uuid']),
-        'short_name': appinfo_c_def['name'],
-        'long_name': appinfo_c_def['name'],
+        'project_name': appinfo_c_def['project_name'],
         'company_name': appinfo_c_def['company_name'],
         'version_code': version_major,
         'version_label': '{}.{}.0'.format(version_major, version_minor),


### PR DESCRIPTION
to meet requirement of FILE_DUMMY_APPINFO

It's probably not the best solution as we lost short_name/long_name (well, they were set to set value before).
A better refactoring would to correctly retrieve short_name, long_name from old PBL_APP_INFO and let them be used in FILE_DUMMY_APPINFO.
(give me units test for the existing code and i will do that refactoring with big pleasure :)

But this solves Hexxeh/libpebble#26 :)
