### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ Interact with your Pebble from OSX, Ubuntu or Debian operating systems.
 * Detailed Lightblue-0.4 installation instructions for earlier version of OSX (10.6) and other OSes can be found [here](http://lightblue.sourceforge.net/#downloads)
 
 
-##1. Install Dependencies
+## 1. Install Dependencies
 
 All supported OSes will require `python 2.7` to operate libpebble. It can be installed [here](http://www.python.org/download/releases/2.7/)
 * `Pyserial`will also be required, is can be installed via [pip](https://pypi.python.org/pypi/pip)
 
-###a. OSX Additional Dependencies
+### a. OSX Additional Dependencies
 
 Installing Lightblue-0.4 in OSX will require the following be installed:
 * `PyObjC` which can be installed via [pip](https://pypi.python.org/pypi/pip)
 * `Xcode 2.1 or later` to build LightAquaBlue framework
 
-###b. Ubuntu Additional Dependencies
+### b. Ubuntu Additional Dependencies
 
 Installing Lightblue-0.4 in Ubuntu requires some extra dependencies be installed via `apt-get install`:
 * `python-dev`
@@ -28,7 +28,7 @@ Installing Lightblue-0.4 in Ubuntu requires some extra dependencies be installed
 * `python-tk` if you wish to use the GUI selection tool
 * `python-bluez`
 
-###c. Debian Additional Dependencies
+### c. Debian Additional Dependencies
 
 Support for lightblue is untested in Debian, however the following should be installed/completed for use with PySerial:
 * Install rfcomm `sudo apt-get install rfcomm`
@@ -45,7 +45,7 @@ Support for lightblue is untested in Debian, however the following should be ins
 * Note that you may have to run libpebble as root with `sudo python pebble.py` in Debian
 
 
-##2. Install Libpebble and Lightblue
+## 2. Install Libpebble and Lightblue
 
 * To install libpebble, clone the current libpebble with lightblue support from `git@github.com:pebble/libpebble.git` to a location of your choosing
 * To install lightblue clone `lightblue-0.4` from `https://github.com/pebble/lightblue-0.4` and then:
@@ -53,13 +53,13 @@ Support for lightblue is untested in Debian, however the following should be ins
     * `sudo python setup.py install`
 
 
-##3. Testing the Connection
+## 3. Testing the Connection
 Note: you should have your bluetooth module enabled before continuing
 
-###a. OSX
+### a. OSX
 When using libpebble on OSX, it is recommended that `--lightblue` be utilized.
 
-#####Using libpebble with --lightblue on OSX
+##### Using libpebble with --lightblue on OSX
 * First install the OSX dependencies, general dependencies and lightblue
 * From the `libpebble` folder, execute the following: `./p.py --lightblue --pair get_time`
 * Note that if no `--pebble_id` is specified before the command, you are provided with a GUI selection tool.
@@ -73,7 +73,7 @@ When using libpebble on OSX, it is recommended that `--lightblue` be utilized.
       export PEBBLE_ID="00:11:22:33:44:55:66"
       ./p.py --lightblue get_time
 
-#####Using libpebble without --lightblue on OSX (MAY CAUSE KERNEL PANICS)
+##### Using libpebble without --lightblue on OSX (MAY CAUSE KERNEL PANICS)
 
 * Pair your Pebble to your computer and make sure it's setup as a serial port. For example it could be exposed as `/dev/tty.Pebble123A-SerialPortSe`. You can accomplish this by using OSX's pairing utility in `System Preferences` --> `Bluetooth` -> `+` --> selecting your pebble `Pebble XXXX` then confirming the pairing code on the Pebble.
 * Once you're paired and the serial port is setup, you can execute commands without the `--lightblue` flag, just ensure that the `--pebble_id` is the 4 letter friendly name of your Pebble, `123A` for example.
@@ -95,11 +95,11 @@ _Automated pairing via `--pair` is not currently supported in Ubuntu_
 * Once an application is installed or re-installed it will be launched automatically. Disable this with `--nolaunch`
 	* for example `./p.py --pebble_id 00:11:22:33:44:55:66 --lightblue reinstall brains.pbw --nolaunch`
 
-#####Installing:
+##### Installing:
 * From your libpebble directory, execute `p.py` with the argument `load <path-to-valid-app>` 
 	* for example: `./p.py --pebble_id 00:11:22:33:44:55:66 --lightblue load brains.pbw`
 
-#####Re-installing
+##### Re-installing
 * To re-install an application, execute `p.py` with the argument `reinstall <path-to-valid-app>`. This will attempt to remove the application by its UUID or, if that fails, the name of the application before installing it once more.
 	* for example: `./p.py --pebble_id 00:11:22:33:44:55:66 --lightblue reinstall brains.pbw`
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
